### PR TITLE
chore(ci): Fix linked version group name

### DIFF
--- a/.github/release-please/config.json
+++ b/.github/release-please/config.json
@@ -11,7 +11,7 @@
     },
     {
       "type": "linked-versions",
-      "group-name": "spell",
+      "groupName": "spell and spell-distro",
       "components": [
         "spell", "spell-distro"
       ]


### PR DESCRIPTION
Should fix `undefined` in changelog:

### **Miscellaneous Chores**
  * **spell**: Synchronize ~undefined~ spell and spell-distro versions