### PR TITLE
fix(cli): create worker-spell if not exists

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish crate snapshots
         if: inputs.snapshot == true
         id: snapshot
-        uses: fluencelabs/github-actions/cargo-publish-snapshot@main
+        uses: fluencelabs/github-actions/cargo-publish-snapshot@fix_cargo_publish_ws_version
         with:
           id: ${{ steps.version.outputs.id }}
           path: src/spell/modules/spell

--- a/src/aqua/installation-spell/src/aqua/deploy.aqua
+++ b/src/aqua/installation-spell/src/aqua/deploy.aqua
@@ -29,18 +29,25 @@ func deploy_single_worker(
 
     worker_id: ?WorkerID
     spell_id: ?SpellID
+
+    -- create Worker or retrieve an existing one via dummy DEAL_ID
     try:
         worker_id <- Worker.create()
-        on worker_id!:
-            spell_id <- PeerSpell.install(air, init_args, trigger_config)
     catch e:
         worker_id <- Worker.get_peer_id()
-        on worker_id!:
-            -- kinda dirty update
+
+    on worker_id!:
+        -- Take existing worker-spell or create a new one
+        try:
             spell_id <- Srv.resolve_alias("worker-spell")
-            Spell spell_id!
+            -- If spell already exists, update 'worker_def_cid' arg in its KV
             app_cid <- Json.stringify(worker_definition)
+            Spell spell_id!
             Spell.set_string("worker_def_cid", app_cid)
+        catch e:
+            -- Create new spell, 'worker_def_cid' will be passed in init_args
+            spell_id <- PeerSpell.install(air, init_args, trigger_config)
+            Srv.add_alias("worker-spell", spell_id!)
 
     <- spell_id!, worker_id!
 


### PR DESCRIPTION
before this fix, `deploy_single_worker` was failing if there's no `worker-spell` alias on a worker