### PR TITLE
feat(mailbox): get_mailbox returns in FIFO order [NET-508]

### DIFF
--- a/src/spell/modules/spell/spell/src/log.rs
+++ b/src/spell/modules/spell/spell/src/log.rs
@@ -129,7 +129,6 @@ mod tests {
         let store = spell.store_log_cp(log1.clone(), cp.clone());
         assert!(store.success, "{}", store.error);
 
-        std::thread::sleep(std::time::Duration::from_millis(1500));
         let store = spell.store_log_cp(log2.clone(), cp.clone());
         assert!(store.success, "{}", store.error);
 
@@ -139,7 +138,7 @@ mod tests {
         assert_eq!(logs.len(), 2);
         assert_eq!(logs[0].message, log1);
         assert_eq!(logs[1].message, log2);
-        assert!(logs[0].timestamp < logs[1].timestamp);
+        assert!(logs[0].timestamp <= logs[1].timestamp);
     }
 
     #[marine_test(

--- a/src/spell/modules/spell/spell/src/log.rs
+++ b/src/spell/modules/spell/spell/src/log.rs
@@ -129,7 +129,7 @@ mod tests {
         let store = spell.store_log_cp(log1.clone(), cp.clone());
         assert!(store.success, "{}", store.error);
 
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        std::thread::sleep(std::time::Duration::from_millis(1500));
         let store = spell.store_log_cp(log2.clone(), cp.clone());
         assert!(store.success, "{}", store.error);
 


### PR DESCRIPTION
## Description
Return `get_mailbox` results in FIFO order

## Motivation
Previously, `get_mailbox` results were sorted from the oldest to the latest, so makes it impossible to iterate through results and call `pop_mailbox` (because `pop_mailbox` removes the latest one and we don't have reverse iterator in Aqua).

## Related Issue(s)

## Proposed Changes
Reverse result of `get_mailbox`.

## Checklist
- [x] The code follows the project's coding conventions and style guidelines.
- [x] All tests related to the changes have passed successfully.
- [x] Documentation has been updated to reflect the changes (if applicable).
- [x] All new and existing unit tests have passed.
- [x] I have self-reviewed my code and ensured its quality.
- [x] I have added/updated necessary comments to aid understanding.

## Screenshots (if applicable)
[Add any relevant screenshots or animated GIFs to showcase the changes.]

## Additional Notes
[Provide any additional information or context that may be helpful for the reviewer.]

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to guidelines (https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.