### PR TITLE
fix(installation-spell): fix bug on multiple services installaiton [NET-519]

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -67,8 +67,6 @@ jobs:
       - name: Setup marine
         if: steps.marine.outcome == 'failure'
         uses: fluencelabs/setup-marine@v1
-        with:
-          version: 0.14.2
 
       - name: Build and package spell
         working-directory: ./src/spell/modules/spell/spell

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Setup marine
         if: steps.marine.outcome == 'failure'
         uses: fluencelabs/setup-marine@v1
+        with:
+          version: 0.14.2
 
       - name: Build and package spell
         working-directory: ./src/spell/modules/spell/spell

--- a/fluence.yaml
+++ b/fluence.yaml
@@ -30,6 +30,10 @@
 # appJSPath: ./path/to/app-js/dir # Optional. If you want to generate js files including app.js to be able to access deployed app data in aqua when using FluenceJS
 
 version: 2
+
+dependencies:
+  npm:
+    "@fluencelabs/cli": 0.5.4
 services:
   spell:
     get: src/spell

--- a/fluence.yaml
+++ b/fluence.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=.fluence/schemas/fluence.json
+# yaml-language-server: $schema=.fluence/schemas/fluence.yaml.json
 
 # EXAMPLES:
 # keyPairName: myKeyPairName # Name of key pair to use. Default: defaultKeyPairName from project's .fluence/secretes.yaml or if it is empty - defaultKeyPairName from user's .fluence/secrets.yaml
@@ -30,9 +30,6 @@
 # appJSPath: ./path/to/app-js/dir # Optional. If you want to generate js files including app.js to be able to access deployed app data in aqua when using FluenceJS
 
 version: 2
-dependencies:
-  npm:
-    "@fluencelabs/cli": 0.5.4
 services:
   spell:
     get: src/spell

--- a/src/aqua/installation-spell/src/aqua/spell.aqua
+++ b/src/aqua/installation-spell/src/aqua/spell.aqua
@@ -142,7 +142,6 @@ func deploy_spell(spell: SpellDefinition, ipfs: Multiaddr):
 
 func download_service(s: Service, ipfs: Multiaddr) -> []Hash:
     hashes: *Hash
-    log([s.name, "try to install", s.modules.length, "modules"])
     for m <- s.modules:
         get_wasm <- Ipfs.get_from(m.wasm, ipfs)
         json_cfg <- Ipfs.cat_from(m.config, ipfs)
@@ -166,7 +165,7 @@ func install(ipfs: Multiaddr, worker_def_cid: CID):
 
             for s <- worker_definition.services:
                 try:
-                    hashes = download_service(s, ipfs)
+                    hashes <- download_service(s, ipfs)
                     if hashes.length == s.modules.length:
                         blueprint <- Dist.make_blueprint(s.name, hashes)
                         blueprint_id <- Dist.add_blueprint(blueprint)

--- a/src/aqua/installation-spell/src/aqua/spell.aqua
+++ b/src/aqua/installation-spell/src/aqua/spell.aqua
@@ -6,7 +6,7 @@ import PeerSpell from "@fluencelabs/spell/api.aqua"
 import Srv from "@fluencelabs/aqua-lib/builtin.aqua"
 
 import WDJson, ModuleConfigJson, TriggerConfigJson, JsonStr from "./json.aqua"
-import SpellDefinition from "./config.aqua"
+import SpellDefinition, Service from "./config.aqua"
 import Multiaddr, CID from "./types.aqua"
 import SpellData from "./spell_data.aqua"
 import log from "./log.aqua"
@@ -140,6 +140,20 @@ func deploy_spell(spell: SpellDefinition, ipfs: Multiaddr):
     catch e:
         log(["Error deploy spell", spell.name, e])
 
+func download_service(s: Service, ipfs: Multiaddr) -> []Hash:
+    hashes: *Hash
+    log([s.name, "try to install", s.modules.length, "modules"])
+    for m <- s.modules:
+        get_wasm <- Ipfs.get_from(m.wasm, ipfs)
+        json_cfg <- Ipfs.cat_from(m.config, ipfs)
+        ipfs_ok <- and(get_wasm.success, json_cfg.success)
+        if ipfs_ok:
+            cfg <- ModuleConfigJson.parse(json_cfg.contents)
+            hashes <<- Dist.add_module_from_vault(get_wasm.path, cfg)
+        else:
+            log([s.name, "error retrieving module", ["wasm", m.wasm, get_wasm], ["config", m.config, json_cfg]])
+    <- hashes
+
 func install(ipfs: Multiaddr, worker_def_cid: CID):
     Spell "worker-spell"
 
@@ -152,17 +166,7 @@ func install(ipfs: Multiaddr, worker_def_cid: CID):
 
             for s <- worker_definition.services:
                 try:
-                    hashes: *Hash
-                    for m <- s.modules:
-                        get_wasm <- Ipfs.get_from(m.wasm, ipfs)
-                        json_cfg <- Ipfs.cat_from(m.config, ipfs)
-                        ipfs_ok <- and(get_wasm.success, json_cfg.success)
-                        if ipfs_ok:
-                            cfg <- ModuleConfigJson.parse(json_cfg.contents)
-                            hashes <- Dist.add_module_from_vault(get_wasm.path, cfg)
-                        else:
-                            log([s.name, "error retrieving module", ["wasm", m.wasm, get_wasm], ["config", m.config, json_cfg]])
-
+                    hashes = download_service(s, ipfs)
                     if hashes.length == s.modules.length:
                         blueprint <- Dist.make_blueprint(s.name, hashes)
                         blueprint_id <- Dist.add_blueprint(blueprint)


### PR DESCRIPTION
The problem was here 
```aqua
            for s <- worker_definition.services:
                try:
                    hashes: *Hash
```
For some reason, on the second iteration where the spell tried to install the second service, the `hashes` variable wasn't updated and contained the hashes of the modules from the first iteration.

I wasn't able to reproduce this with a smaller example, but apparently, moving the code out to a separate function helped.  