### PR TITLE
chore: update marine-rs-sdk to enable e2e in sqlite-connector repo

### DIFF
--- a/src/spell/modules/spell/spell-dtos/Cargo.toml
+++ b/src/spell/modules/spell/spell-dtos/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-marine-rs-sdk = "0.7.1"
+marine-rs-sdk = "0.9.0"
 thiserror = "1.0.37"
 marine-sqlite-connector = { workspace = true }
 eyre = "0.6.8"

--- a/src/spell/modules/spell/spell/Cargo.toml
+++ b/src/spell/modules/spell/spell/Cargo.toml
@@ -9,7 +9,7 @@ name = "spell"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.7.1"
+marine-rs-sdk = "0.9.0"
 marine-sqlite-connector = { workspace = true }
 eyre = "0.6.8"
 cid = "0.10.0"


### PR DESCRIPTION
This is to fix failing e2e in wasm-sqlite-connector repo