### PR TITLE
fix(installation-spell): remove get_trigger [NET-533]

### DIFF
--- a/integration-tests/framework.py
+++ b/integration-tests/framework.py
@@ -9,7 +9,7 @@ import os
 from config import get_local
 import tempfile
 
-key_lock = filelock.FileLock("spell_test_run.lock", timeout=120)
+key_lock = filelock.FileLock("spell_test_run.lock", timeout=150)
 def make_key():
     with key_lock:
         name = ''.join(random.choices(string.ascii_uppercase, k=5))

--- a/src/aqua/spell/trigger.aqua
+++ b/src/aqua/spell/trigger.aqua
@@ -15,3 +15,6 @@ data PeerTrigger:
 data TriggerEvent:
   timer: ?TimerTrigger
   peer: ?PeerTrigger
+
+service TriggerEventJson("json"):
+  parse(s: JsonString) -> TriggerEvent

--- a/src/aqua/spell/trigger.aqua
+++ b/src/aqua/spell/trigger.aqua
@@ -4,6 +4,7 @@ import "@fluencelabs/aqua-lib/builtin.aqua"
 import Spell, TriggerConfig from "spell_service.aqua"
 import JsonString, Error from "types.aqua"
 
+-- TODO: should we move it to types.aqua??
 data TimerTrigger:
   timestamp: u64
 
@@ -14,26 +15,3 @@ data PeerTrigger:
 data TriggerEvent:
   timer: ?TimerTrigger
   peer: ?PeerTrigger
-
-service TriggerEventJson("json"):
-    parse(s: JsonString) -> TriggerEvent
-
--- Returns TriggerEvent if any
--- Returns string Error if there was an error reading from Spell Mailbox
--- Returns (nil, nil) if there was no TriggerEvent and no errors during Mailbox read
--- Can be called only by Worker that created the Spell
-func get_trigger(spell_id: string) -> ?TriggerEvent, ?Error:
-    trigger: ?TriggerEvent
-    error: ?Error
-
-    Spell spell_id
-    s <- Spell.pop_mailbox()
-
-    if s.success:
-      if s.absent == false:
-        -- How to check that s.message is a valid TriggerEvent???
-        trigger <- TriggerEventJson.parse(s.message!.message)
-    else:
-      error <<- s.error
-
-    <- trigger, error


### PR DESCRIPTION
## Description
Remove `get_trigger` from installation-spell npm package.

## Motivation
After fluencelabs/nox#1728 trigger is accessible via func arguments like this:
```
import TriggerEvent from "@fluencelabs/spell/trigger.aqua"

func spell_main(trigger: TriggerEvent, init_arg1: string, ...):
    ...
```
## Related Issue(s)
- [[NET-511]](https://linear.app/fluence/issue/NET-511/pass-trigger-event-as-an-arg-to-spell)
## Proposed Changes
Remove `get_trigger`
## Checklist
- [ ] The code follows the project's coding conventions and style guidelines.
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.

## Reviewer Checklist
- [ ] Code has been reviewed for quality and adherence to [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] Tests have been reviewed and are sufficient to validate the changes.
- [ ] Documentation has been reviewed and is up to date.
- [ ] Any questions or concerns have been addressed.

