### PR TITLE
feat(service,API): add list_remove_value [fixes NET-648]

### DIFF
--- a/src/aqua/spell/spell_service.aqua
+++ b/src/aqua/spell/spell_service.aqua
@@ -125,6 +125,7 @@ service Spell:
   list_get_strings(key: string) -> StringListValue
   list_pop_string(key: string) -> StringValue
   list_push_string(key: string, value: string) -> UnitValue
+  list_remove_value(key: string, value: string) -> UnitValue
   pop_mailbox() -> PopMailboxResult
   push_mailbox(message: string) -> UnitValue
   remove_key(key: string) -> UnitValue

--- a/src/spell/modules/spell/spell/src/kv/collection.rs
+++ b/src/spell/modules/spell/spell/src/kv/collection.rs
@@ -98,6 +98,7 @@ pub fn list_get_strings(key: &str) -> StringListValue {
 pub fn list_remove_value(key: &str, value: &str) -> UnitValue {
     let conn = db();
     let result: eyre::Result<()> = try {
+        // list_order == -1 when the key isn't a part of a list
         let mut statement = conn.prepare(
             r#"
             DELETE FROM kv

--- a/src/spell/modules/spell/spell/src/kv/collection.rs
+++ b/src/spell/modules/spell/spell/src/kv/collection.rs
@@ -15,7 +15,14 @@ pub fn list_push_string(key: &str, value: String) -> UnitValue {
                     VALUES (
                         ?,
                         ?,
-                        (SELECT COUNT(*) FROM kv WHERE key = ?)
+                        COALESCE(
+                            (
+                                SELECT MAX(list_index) + 1
+                                FROM kv
+                                WHERE key = ?
+                            ),
+                            0
+                        )
                     )
             "#,
         )?;
@@ -35,13 +42,11 @@ pub fn list_pop_string(key: &str) -> StringValue {
     let result: eyre::Result<Option<String>> = try {
         let mut get = db.prepare(
             r#"
-            SELECT string, list_index FROM kv
+            SELECT string, max(list_index) FROM kv
                 WHERE key = ?
-                AND list_index = ((SELECT COUNT(*) FROM kv WHERE key = ?) - 1)
         "#,
         )?;
         get.bind(1, key)?;
-        get.bind(2, key)?;
 
         let mut result = None;
 
@@ -72,6 +77,8 @@ pub fn list_get_strings(key: &str) -> StringListValue {
                 string
             FROM
                 kv WHERE key = ?
+            ORDER BY
+                list_index ASC
         "#,
         )?;
         statement.bind(1, key)?;
@@ -80,6 +87,36 @@ pub fn list_get_strings(key: &str) -> StringListValue {
         });
 
         list
+    };
+
+    result.into()
+}
+
+#[marine]
+/// Remove a value from a list of strings. If the value is in several places, remove all of them.
+/// `list_index` is used to preserve order of elements in a list, not the actual index.
+/// TODO: change `list_index` to `list_order` in the future when we'll change Spell Service API
+///
+pub fn list_remove_value(key: &str, value: &str) -> UnitValue {
+    let conn = db();
+    let result: eyre::Result<()> = try {
+        let mut statement = conn.prepare(
+            r#"
+            DELETE FROM kv
+                WHERE key = ?
+                  AND string = ?
+                  AND list_index != -1
+            RETURNING list_index
+        "#,
+        )?;
+        statement.bind(1, key)?;
+        statement.bind(2, value)?;
+        let list: Vec<i64> = fetch_rows(statement, |statement| {
+            Ok(Some(statement.read::<i64>(0)?))
+        });
+        if list.len() == 0 {
+            return Err(eyre::eyre!("value not found"))?;
+        }
     };
 
     result.into()
@@ -160,4 +197,62 @@ mod tests {
         let get = spell.list_get_strings(key.into());
         assert_eq!(get.strings, &["хаха", "хаха", "haha"]);
     }
+
+    #[marine_test(config_path = "../../tests_artifacts/Config.toml")]
+    fn test_list_remove(spell: marine_test_env::spell::ModuleInterface) {
+        let key = "a";
+        let value = "value_to_remove";
+
+        let _ = spell.list_push_string(key.into(), "b".into());
+        let _ = spell.list_push_string(key.into(), value.into());
+        let _ = spell.list_push_string(key.into(), "в".into());
+        let _ = spell.list_push_string(key.into(), "p".into());
+        let _ = spell.list_push_string(key.into(), value.into());
+        let _ = spell.list_push_string(key.into(), "a".into());
+
+        let remove = spell.list_remove_value(key.into(), value.into());
+        assert!(remove.success, "remove failed {}", remove.error);
+
+        let get = spell.list_get_strings(key.into());
+        assert!(get.success, "list_get_strings failed {}", get.error);
+        assert_eq!(get.strings, vec!["b", "в", "p", "a"]);
+
+        let remove = spell.list_remove_value(key.into(), "not-in-list".into());
+        assert!(!remove.success, "remove must fail since the value isn't in the list");
+
+
+        let _ = spell.set_string("str".into(), "val".into());
+        let remove = spell.list_remove_value("str".into(), "val".into());
+        assert!(!remove.success, "remove must fail since the key isn't a list");
+    }
+
+    #[marine_test(config_path = "../../tests_artifacts/Config.toml")]
+    fn test_list_remove_and_add(spell: marine_test_env::spell::ModuleInterface) {
+        let key = "a";
+        let value = "value_to_remove";
+        let value_first = "value_first";
+
+        let _ = spell.list_push_string(key.into(), value_first.into());
+        let _ = spell.list_push_string(key.into(), value.into());
+        let _ = spell.list_push_string(key.into(), "в".into());
+        let _ = spell.list_push_string(key.into(), "p".into());
+        let _ = spell.list_push_string(key.into(), value.into());
+        let _ = spell.list_push_string(key.into(), "a".into());
+
+        let _ = spell.list_remove_value(key.into(), value.into());
+
+        let _ = spell.list_push_string(key.into(), "n1".into());
+        let _ = spell.list_push_string(key.into(), "n2".into());
+
+        let get = spell.list_get_strings(key.into());
+        assert!(get.success, "list_get_strings failed {}", get.error);
+        assert_eq!(get.strings, vec![value_first, "в", "p", "a", "n1", "n2"]);
+
+        let _ = spell.list_remove_value(key.into(), value_first.into());
+        let get = spell.list_get_strings(key.into());
+        assert!(get.success, "list_get_strings failed {}", get.error);
+        assert_eq!(get.strings, vec!["в", "p", "a", "n1", "n2"]);
+
+    }
+
 }

--- a/src/spell/modules/spell/spell/src/schema.rs
+++ b/src/spell/modules/spell/spell/src/schema.rs
@@ -32,14 +32,14 @@ pub fn create() {
 
             CREATE TABLE IF NOT EXISTS relay (relay TEXT);
 
-            -- CREATE TABLE IF NOT EXISTS kv (key TEXT, string TEXT, u32 INTEGER, list_index INTEGER);
+            -- CREATE TABLE IF NOT EXISTS kv (key TEXT, string TEXT, u32 INTEGER, list_order INTEGER);
             CREATE TABLE IF NOT EXISTS kv (
                 key TEXT NOT NULL,
                 string TEXT,
                 u32 INTEGER,
-                list_index INTEGER DEFAULT -1,
+                list_order INTEGER DEFAULT -1,
 
-                PRIMARY KEY(key, list_index)
+                PRIMARY KEY(key, list_order)
             );
 
             -- particles stored in the database, LRU-like


### PR DESCRIPTION
**Changes**:
- Added `list_remove_value` that removes all entries of `value` in the list by the given `key`.
- Renamed `list_index` to `list_order` name, since now this value specifies the relative order of elements in the list, not their indices.
- Fix `list_pop_string` and `list_push_string` to rely on this `list_order` when evaluating indices rather than on the number of values in the list.